### PR TITLE
Need to fix some minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.1] - 2020/06/04
+
+* Minro fixes.
+
 ## [1.5.0] - 2020/06/04
 
 * Added feature faded edges

--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -511,10 +511,10 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
   /// A timer that is fired at the start of each round.
   bool _running = false;
   bool _isOnPause = false;
-  int _roundCounter = 1;
+  int _roundCounter = 0;
   bool get isDone => widget.numberOfRounds == null
       ? false
-      : _roundCounter > widget.numberOfRounds;
+      : widget.numberOfRounds == _roundCounter;
   bool get showFading =>
       !widget.showFadingOnlyWhenScrolling ? true : !_isOnPause;
 
@@ -607,12 +607,16 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
     if (!_running) return;
 
     await _decelerate();
-    if (!_running) return;
-    setState(() => _isOnPause = true);
-    await Future.delayed(widget.pauseAfterRound);
-    setState(() => _isOnPause = false);
-    await Future.delayed(widget.pauseAfterRound);
+
     _roundCounter++;
+
+    if (!_running || !mounted) return;
+    setState(() => _isOnPause = true);
+
+    await Future.delayed(widget.pauseAfterRound);
+
+    if (!mounted || isDone) return;
+    setState(() => _isOnPause = false);
   }
 
   // Methods that animate the controller.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: marquee
 description: "⏩ A Flutter widget that scrolls text infinitely. Provides many
   customizations including custom scroll directions, durations, curves as well
   as pauses after every round."
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/marcelgarus/marquee
 issue_tracker: https://github.com/marcelgarus/marquee/issues
 


### PR DESCRIPTION
Duplicated line, line 614, sorry about that, the pause was executed twice.
We need to check that the widget is mounted before the setState otherwise it will produce the `Unhandled exception: SetState() called after dispose`
Also, _makeRoundTrip has to return before the setState() if isDone is set to true, otherwise the edges will fade (if settled)  after the pause
Pubspec.yaml version and Changelog have been updated
Thank you