### PR TITLE
Improve the pauseAfterRound sample code

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -276,8 +276,8 @@ class Marquee extends StatefulWidget {
   ///
   /// ```dart
   /// Marquee(
-  ///   pauseAfterRound: Duration(seconds: 1),
-  ///   text: 'Pausing for some time after every round.'
+  ///   pauseAfterRound: const Duration(seconds: 1),
+  ///   text: 'Pausing for some time after every round.',
   /// )
   /// ```
   ///


### PR DESCRIPTION
The Duration can be const, and the text argument should have a trailing comma.