### PR TITLE
Fix '_positions.isNotEmpty': ScrollController not attached to any scroll views.

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -554,7 +554,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
 
   Future<bool> _scroll() async {
     await _makeRoundTrip();
-    return _running && !isDone;
+    return _running && !isDone && _controller.hasClients;
   }
 
   @override
@@ -618,6 +618,8 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
 
   /// Causes the controller to scroll one round.
   Future<void> _makeRoundTrip() async {
+
+    if (!_controller.hasClients) return;
     // Reset the controller, then accelerate, move linearly and decelerate.
     _controller.jumpTo(_startPosition);
     if (!_running) return;
@@ -734,7 +736,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
   Widget _wrapWithFadingEdgeScrollView(Widget child) {
     return FadingEdgeScrollView.fromScrollView(
       gradientFractionOnStart:
-      !showFading ? 0.0 : widget.fadingEdgeStartFraction,
+          !showFading ? 0.0 : widget.fadingEdgeStartFraction,
       gradientFractionOnEnd: !showFading ? 0.0 : widget.fadingEdgeEndFraction,
       child: child,
     );


### PR DESCRIPTION
I have a big application and I used your widget package (I have music player and I use it for my song title in the player page, like in YT Music), though when I replace it fast in the widget tree, i.e. fast tap on my "next song" button, it turns out there's a bug in it and the following exception is being thrown: 
`AssertionError('Fix 'package:flutter/src/widgets/scroll_controller.dart': Failed assertion: line 176 pos 12: '_positions.isNotEmpty': ScrollController not attached to any scroll views.')`.

This PR fixes it.

***Videos:***
[Error](https://youtu.be/6EwTd3POIxY)
[Same thing but with my fix](https://youtu.be/5fO8akuHNps)