### PR TITLE
Added support to `textScaleFactor`

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -198,7 +198,7 @@ class Marquee extends StatefulWidget {
   ///
   /// * [text] to provide the text itself.
   final TextStyle style;
-  
+
   /// The font scale of the text to be displayed.
   ///
   /// ## Sample code
@@ -215,7 +215,7 @@ class Marquee extends StatefulWidget {
   /// See also:
   ///
   /// * [text] to provide the text itself.
-  final int textScaleFactor;
+  final double textScaleFactor;
 
   /// The scroll axis.
   ///
@@ -688,7 +688,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
 
   /// Returns the width of the text.
   double _getTextWidth(BuildContext context) {
-    final span = TextSpan(text: widget.text, style: widget.style, textScaleFactor: widget.textScaleFactor);
+    final span = TextSpan(text: widget.text, style: widget.style);
 
     final constraints = BoxConstraints(maxWidth: double.infinity);
 
@@ -734,7 +734,8 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
       physics: NeverScrollableScrollPhysics(),
       itemBuilder: (_, i) {
         final text = i.isEven
-            ? Text(widget.text, style: widget.style, textScaleFactor: widget.textScaleFactor)
+            ? Text(widget.text,
+                style: widget.style, textScaleFactor: widget.textScaleFactor)
             : _buildBlankSpace();
         return alignment == null
             ? text

--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -96,6 +96,7 @@ class Marquee extends StatefulWidget {
     Key key,
     @required this.text,
     this.style,
+    this.textScaleFactor,
     this.scrollAxis = Axis.horizontal,
     this.crossAxisAlignment = CrossAxisAlignment.center,
     this.blankSpace = 0.0,
@@ -197,6 +198,24 @@ class Marquee extends StatefulWidget {
   ///
   /// * [text] to provide the text itself.
   final TextStyle style;
+  
+  /// The font scale of the text to be displayed.
+  ///
+  /// ## Sample code
+  ///
+  /// This marquee has a fixed text scale factor, indipendent to the user selected resolution:
+  ///
+  /// ```dart
+  /// Marquee(
+  ///   text: 'This is some bold text.',
+  ///   textScaleFactor: 1
+  /// )
+  /// ```
+  ///
+  /// See also:
+  ///
+  /// * [text] to provide the text itself.
+  final int textScaleFactor;
 
   /// The scroll axis.
   ///
@@ -499,6 +518,7 @@ class Marquee extends StatefulWidget {
     return other is Marquee &&
         text == other.text &&
         style == other.style &&
+        textScaleFactor == other.textScaleFactor &&
         scrollAxis == other.scrollAxis &&
         blankSpace == other.blankSpace &&
         velocity == other.velocity &&
@@ -668,7 +688,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
 
   /// Returns the width of the text.
   double _getTextWidth(BuildContext context) {
-    final span = TextSpan(text: widget.text, style: widget.style);
+    final span = TextSpan(text: widget.text, style: widget.style, textScaleFactor: widget.textScaleFactor);
 
     final constraints = BoxConstraints(maxWidth: double.infinity);
 
@@ -714,7 +734,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
       physics: NeverScrollableScrollPhysics(),
       itemBuilder: (_, i) {
         final text = i.isEven
-            ? Text(widget.text, style: widget.style)
+            ? Text(widget.text, style: widget.style, textScaleFactor: widget.textScaleFactor)
             : _buildBlankSpace();
         return alignment == null
             ? text


### PR DESCRIPTION
Added a new property, the `textScaleFactor`, that map the corresponding `textScaleFactor` of the standard `Text` widget.

This property is fundamental in our production app, to correctly manage the accessibility options for scaled text.