### PR TITLE
Fix initial padding and startPosition when scrolling is delayed

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -521,6 +521,7 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
     WidgetsBinding.instance!.addPostFrameCallback((_) async {
       if (!_running) {
         _running = true;
+        _controller.jumpTo(_startPosition);
         await Future<void>.delayed(widget.startAfter);
         Future.doWhile(_scroll);
       }


### PR DESCRIPTION
When you add a `startPadding` and use the `startAfter` to delay the scrolling after 'n' seconds: on this few 'n' seconds the `startPadding` is not applied (internally, the `startPosition` is not correctly set).

Below, on the first 5 seconds, you can see that the `startPadding` is ignored, and cause a "jump" effect when it starts scrolling:

![Apr-08-2021 10-55-30](https://user-images.githubusercontent.com/1045997/113998551-76f1c700-9859-11eb-9ced-6fc210d29b0a.gif)

```dart
Marquee(
  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
  scrollAxis: Axis.horizontal,
  crossAxisAlignment: CrossAxisAlignment.start,
  blankSpace: 100.0,
  showFadingOnlyWhenScrolling: false,
  fadingEdgeStartFraction: 0.1,
  fadingEdgeEndFraction: 0.1,
  startPadding: 15,
  startAfter: Duration(seconds: 3),
  pauseAfterRound: Duration(seconds: 5),
),
```

This fix here ensures that the `startPosition` is correctly set from the `initState` of this Widget.
