### PR TITLE
Updated fading_edge_scrollview to 3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  fading_edge_scrollview: ^2.0.0
+  fading_edge_scrollview: ^3.0.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR updates the fading_edge_scrollview dependency to version 3.0.0 to resolve compiler warnings due to Flutter 3 as described in issue #79 