### PR TITLE
ListView items causing neighbouring widgets to repaint

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -733,9 +733,10 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
             ? Text(widget.text,
                 style: widget.style, textScaleFactor: widget.textScaleFactor)
             : _buildBlankSpace();
-        return alignment == null
-            ? text
-            : Align(alignment: alignment, child: text);
+        return RepaintBoundary(
+            child: alignment == null
+                ? text
+                : Align(alignment: alignment, child: text));
       },
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  fading_edge_scrollview: ^3.0.0
+  fading_edge_scrollview: ^4.1.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
I faced this issue while working on a project.
The whole scaffold and bottom navbar were getting repainted everything marquee list was getting scrolled.

To cross check you can use `debugRepaintRainbowEnabled =true` and put it at the start of the `main` function
It will show all the boundaries. You will notice all the boundary colours getting changed when the marquee list is getting scrolled by the controller. To restrict the repaint of all the neighbouring widgets I wrapped the list Items with RepaintBoundary. 