### PR TITLE
fix: customized textScaleFactor causes jumping text

### DIFF
--- a/lib/marquee.dart
+++ b/lib/marquee.dart
@@ -687,7 +687,9 @@ class _MarqueeState extends State<Marquee> with SingleTickerProviderStateMixin {
 
     final constraints = BoxConstraints(maxWidth: double.infinity);
 
-    final richTextWidget = Text.rich(span).build(context) as RichText;
+    final richTextWidget =
+        Text.rich(span, textScaleFactor: widget.textScaleFactor).build(context)
+            as RichText;
     final renderObject = richTextWidget.createRenderObject(context);
     renderObject.layout(constraints);
 


### PR DESCRIPTION
When applying a custom `textScaleFactor` to `Marquee` there is a visible jump when the animation repeats. This was caused by not taking `textScaleFactor` into account when calculating the text width.