### PR TITLE
Upgraded fading_edge_scrollview to ^4.0.0. Fixes #95

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,10 @@ repository: https://github.com/MarcelGarus/marquee
 
 environment:
   flutter: '>=3.0.0'
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
-  fading_edge_scrollview: ^3.0.0
+  fading_edge_scrollview: ^4.0.0
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
-  fading_edge_scrollview: ^4.0.0
+  fading_edge_scrollview: ^4.1.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
# Fixes build for flutter 3.22.0.

Upgraded to ^4.0.0 of fading_edge_scrollview.

# Related items

Fixes #95